### PR TITLE
fixup bubble links on matrix reloaded action have incorect url

### DIFF
--- a/src/main/resources/net/praqma/jenkins/plugin/reloaded/MatrixReloadedAction/main.jelly
+++ b/src/main/resources/net/praqma/jenkins/plugin/reloaded/MatrixReloadedAction/main.jelly
@@ -33,7 +33,7 @@
 				height="24" width="24" />
 		</j:when>
 		<j:otherwise>
-			<a href="${p.nearestRunUrl}" class="model-link inside">
+			<a href="${request.getRootPath()}/${b.getUrl()}" class="model-link inside">
 				<img src="${imagesURL}/24x24/${b.buildStatusUrl}" tooltip="${p.tooltip} ${build.number!=b.number?(build.isBuilding()?'- pending' : '- skipped'):''}" alt="${p.tooltip}" style="${build.number!=b.number?'opacity:0.5':''}" height="24" width="24"/>
 				<j:if test="${empty(o.x) and empty(o.y)}">
 					${p.combination.toString(o.z)}


### PR DESCRIPTION
see JENKINS-17748

Bubble links on matrix reloaded action have incorect url
On **/job/<job>/<configuration>/<build>/matrix-reloaded** 
there are relative links to <configuration>/ effectively pointing at
 **/job/<job>/<configuration>/<build>/matrix-reloaded/<configuration>** that does not exist.


Signed-off-by: Mamh-windows <bright.ma@mage.com>